### PR TITLE
「位置を数値で見てみよう」の修正

### DIFF
--- a/JavajoTeachingForKids/src/main/resources/static/js/coordinate002.js
+++ b/JavajoTeachingForKids/src/main/resources/static/js/coordinate002.js
@@ -12,8 +12,8 @@ window.onload = function() {
 
     // ゲーム本体の描画
     core.onload = function() {
-        document.getElementById('location-x').value=0;
-        document.getElementById('location-y').value=0;
+        document.getElementById('location-x').value=1;
+        document.getElementById('location-y').value=1;
         core.replaceScene(createGameScene());
     };
 
@@ -44,10 +44,6 @@ function createGameScene() {
     	// タッチした位置に移動
     	targetX = e.x - (bear.width/2);	// スプライト幅の半分の値を引くことで中央にする
     	targetY = e.y - (bear.height/2);	// スプライト高さの半分の値を引くことで中央にする
-
-    	//タッチした座標表示(小数点は四捨五入)
-        document.getElementById('location-x').value=Math.round(targetX);
-        document.getElementById('location-y').value=Math.round(targetY);
     });
     	// タッチ終了
     scene.addEventListener("touchend", function(e) { isTouch = false; });
@@ -65,6 +61,10 @@ function createGameScene() {
     	// 徐々にタッチした位置に近づける
     	var moveX = (targetX - bear.x)*0.25;
     	var moveY = (targetY - bear.y)*0.25;
+    	//タッチした座標表示(小数点は四捨五入)
+    	document.getElementById('location-x').value=Math.round((bear.x+8)/16+1);
+        document.getElementById('location-y').value=Math.round((bear.y+16)/16+1);
+        //移動
     	bear.moveBy(moveX, moveY);
     	}
     });

--- a/JavajoTeachingForKids/src/main/resources/templates/coordinate002.html
+++ b/JavajoTeachingForKids/src/main/resources/templates/coordinate002.html
@@ -26,14 +26,14 @@
                         <p>クマはここにいるよ</p>
                         <div class="col-sm-6">
                             <div class="input-group input-group-lg">
-                                <span class="input-group-addon">X（左右）</span>
-                                <textarea type="text" class="form-control" value="" id="location-x" />
+                                <span class="input-group-addon">よこ</span>
+                                <input type="text" class="form-control" value="" id="location-x" readonly="readonly"/>
                             </div>
                         </div>
                         <div class="col-sm-6">
                             <div class="input-group input-group-lg">
-                                <span class="input-group-addon">Y（上下）</span>
-                                <textarea type="text" class="form-control" value="" id="location-y" />
+                                <span class="input-group-addon">たて</span>
+                                <input type="text" class="form-control" value="" id="location-y" readonly="readonly"/>
                             </div>
                         </div>
                     </div>

--- a/JavajoTeachingForKids/src/main/resources/templates/coordinate002.html
+++ b/JavajoTeachingForKids/src/main/resources/templates/coordinate002.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8" />
-    <title>位置を数値で見てみよう!</title>
+    <title>ざひょうを数で見てみよう！</title>
     <link th:substituteby="common/head :: common_head"/>
     <link th:substituteby="common/head-chat :: common_head_chat"/>
     <script type="text/javascript" src="enchant.js"></script>
@@ -20,7 +20,7 @@
             <div class="col-sm-12">
                 <div class="panel panel-success">
                     <div class="panel-heading">
-                        <h2 class="panel-title">位置を数値で見てみよう!</h2>
+                        <h2 class="panel-title">ざひょうを数で見てみよう！</h2>
                     </div>
                     <div class="panel-body">
                         <p>クマはここにいるよ</p>


### PR DESCRIPTION
#42 、#49 の指摘修正しました。

・タイトルの修正。
・座標表示を読み取り専用にする。
・画面文言（x、y）→よこ、たてに修正。
・座標の表示形式を20×20になるように修正。

あわせて
座標の表示位置がクリックした場所になっていたので、くまの座標を表示するようにしました。
